### PR TITLE
Update to `URLRequest` instead of `URL` in `Endpoint`

### DIFF
--- a/Sources/TinyNetwork/Endpoints/DecodableEndpoint.swift
+++ b/Sources/TinyNetwork/Endpoints/DecodableEndpoint.swift
@@ -10,13 +10,17 @@ import Foundation
 public struct DecodableEndpoint<Resource>: Endpoint where Resource: Decodable {
     public typealias Value = Resource
 
-    public let url: URL
+    public let urlRequest: URLRequest
 
     public var parse: (Data) throws -> Value = { data in
         try JSONDecoder().decode(Resource.self, from: data)
     }
 
     public init(url: URL) {
-        self.url = url
+        self.urlRequest = URLRequest(url: url)
+    }
+    
+    public init(urlRequest: URLRequest) {
+        self.urlRequest = urlRequest
     }
 }

--- a/Sources/TinyNetwork/Endpoints/Endpoint.swift
+++ b/Sources/TinyNetwork/Endpoints/Endpoint.swift
@@ -10,8 +10,6 @@ import Foundation
 public protocol Endpoint {
     associatedtype Value
     
-    var url: URL { get }
+    var urlRequest: URLRequest { get }
     var parse: (Data) throws -> Value { get }
-    
-    init(url: URL)
 }

--- a/Sources/TinyNetwork/Endpoints/ImageEndpoint.swift
+++ b/Sources/TinyNetwork/Endpoints/ImageEndpoint.swift
@@ -12,7 +12,7 @@ import UIKit
 @available(iOS 13.0, watchOS 6.0, *)
 public struct ImageEndpoint: Endpoint {
     public typealias Value = Image
-    public let url: URL
+    public let urlRequest: URLRequest
     
     public let parse: (Data) throws -> Value = { data in
         guard let image = UIImage(data: data) else {
@@ -22,6 +22,10 @@ public struct ImageEndpoint: Endpoint {
     }
     
     public init(url: URL) {
-        self.url = url
+        self.urlRequest = URLRequest(url: url)
+    }
+    
+    public init(urlRequest: URLRequest) {
+        self.urlRequest = urlRequest
     }
 }

--- a/Sources/TinyNetwork/Endpoints/UIImageEndpoint.swift
+++ b/Sources/TinyNetwork/Endpoints/UIImageEndpoint.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public struct UIImageEndpoint: Endpoint {
     public typealias Value = UIImage
-    public let url: URL
+    public let urlRequest: URLRequest
     
     public let parse: (Data) throws -> Value = { data in
         guard let image = UIImage(data: data) else {
@@ -20,6 +20,10 @@ public struct UIImageEndpoint: Endpoint {
     }
     
     public init(url: URL) {
-        self.url = url
+        self.urlRequest = URLRequest(url: url)
+    }
+    
+    public init(urlRequest: URLRequest) {
+        self.urlRequest = urlRequest
     }
 }

--- a/Sources/TinyNetwork/URLSession+Endpoint.swift
+++ b/Sources/TinyNetwork/URLSession+Endpoint.swift
@@ -10,7 +10,7 @@ import Combine
 
 public extension URLSession {
     func dataTask<E: Endpoint>(with endpoint: E, completionHandler: @escaping (Swift.Result<E.Value, Swift.Error>) -> Void) -> URLSessionDataTask {
-        dataTask(with: endpoint.url) { data, _, error in
+        dataTask(with: endpoint.urlRequest) { data, _, error in
             do {
                 if let error = error {
                     throw error
@@ -26,7 +26,7 @@ public extension URLSession {
 @available(iOS 13, watchOS 6, OSX 10.15, *)
 public extension URLSession {
     func dataTaskPublisher<E: Endpoint>(for endpoint: E) -> AnyPublisher<E.Value, Swift.Error> {
-        dataTaskPublisher(for: endpoint.url)
+        dataTaskPublisher(for: endpoint.urlRequest)
             .tryMap { data, _ -> E.Value in
                 try endpoint.parse(data)
             }

--- a/Tests/TinyNetworkTests/DecodableEndpointTests.swift
+++ b/Tests/TinyNetworkTests/DecodableEndpointTests.swift
@@ -9,16 +9,24 @@ import XCTest
 @testable import TinyNetwork
 
 class DecodableEndpointTests: XCTestCase {
-    private var url: URL!
-    private var endpoint: DecodableEndpoint<MockResource>!
+    typealias Endpoint = DecodableEndpoint<MockResource>
+    
+    var url: URL!
+    var endpoint: Endpoint!
     
     override func setUpWithError() throws {
         url = try XCTUnwrap(URL(string: "https://www.github.com"))
-        endpoint = DecodableEndpoint<MockResource>(url: url)
+        endpoint = Endpoint(url: url)
     }
 
     func testURL() throws {
-        XCTAssertEqual(endpoint.url, url)
+        XCTAssertEqual(endpoint.urlRequest.url, url)
+    }
+    
+    func testURLRequest() throws {
+        let urlRequest = URLRequest(url: url)
+        let endpoint = Endpoint(urlRequest: urlRequest)
+        XCTAssertEqual(endpoint.urlRequest, urlRequest)
     }
 
     func testParse() throws {
@@ -26,8 +34,12 @@ class DecodableEndpointTests: XCTestCase {
         let data = try JSONEncoder().encode(resource)
         XCTAssertEqual(try endpoint.parse(data), resource)
     }
+    
+    // MARK: Mocks
+    
+    struct MockResource: Codable, Equatable {
+        let name: String
+    }
 }
 
-private struct MockResource: Codable, Equatable {
-    let name: String
-}
+

--- a/Tests/TinyNetworkTests/DecodableEndpointTests.swift
+++ b/Tests/TinyNetworkTests/DecodableEndpointTests.swift
@@ -10,10 +10,10 @@ import XCTest
 
 class DecodableEndpointTests: XCTestCase {
     typealias Endpoint = DecodableEndpoint<MockResource>
-    
+
     var url: URL!
     var endpoint: Endpoint!
-    
+
     override func setUpWithError() throws {
         url = try XCTUnwrap(URL(string: "https://www.github.com"))
         endpoint = Endpoint(url: url)
@@ -22,7 +22,7 @@ class DecodableEndpointTests: XCTestCase {
     func testURL() throws {
         XCTAssertEqual(endpoint.urlRequest.url, url)
     }
-    
+
     func testURLRequest() throws {
         let urlRequest = URLRequest(url: url)
         let endpoint = Endpoint(urlRequest: urlRequest)
@@ -34,12 +34,10 @@ class DecodableEndpointTests: XCTestCase {
         let data = try JSONEncoder().encode(resource)
         XCTAssertEqual(try endpoint.parse(data), resource)
     }
-    
+
     // MARK: Mocks
-    
+
     struct MockResource: Codable, Equatable {
         let name: String
     }
 }
-
-

--- a/Tests/TinyNetworkTests/ImageEndpointTests.swift
+++ b/Tests/TinyNetworkTests/ImageEndpointTests.swift
@@ -10,17 +10,24 @@ import SwiftUI
 @testable import TinyNetwork
 
 class ImageEndpointTests: XCTestCase {
+    typealias Endpoint = ImageEndpoint
     
     var url: URL!
-    var endpoint: ImageEndpoint!
+    var endpoint: Endpoint!
     
     override func setUpWithError() throws {
         url = try XCTUnwrap(URL(string: "https://www.github.com/image.png"))
-        endpoint = ImageEndpoint(url: url)
+        endpoint = Endpoint(url: url)
     }
 
     func testURL() throws {
-        XCTAssertEqual(endpoint.url, url)
+        XCTAssertEqual(endpoint.urlRequest.url, url)
+    }
+    
+    func testURLRequest() throws {
+        let urlRequest = URLRequest(url: url)
+        let endpoint = Endpoint(urlRequest: urlRequest)
+        XCTAssertEqual(endpoint.urlRequest, urlRequest)
     }
     
     func testParse() throws {

--- a/Tests/TinyNetworkTests/UIImageEndpointTests.swift
+++ b/Tests/TinyNetworkTests/UIImageEndpointTests.swift
@@ -9,17 +9,24 @@ import XCTest
 @testable import TinyNetwork
 
 class UIImageEndpointTests: XCTestCase {
+    typealias Endpoint = UIImageEndpoint
 
     var url: URL!
     var endpoint: UIImageEndpoint!
     
     override func setUpWithError() throws {
         url = try XCTUnwrap(URL(string: "https://www.github.com/image.png"))
-        endpoint = UIImageEndpoint(url: url)
+        endpoint = Endpoint(url: url)
     }
 
     func testURL() throws {
-        XCTAssertEqual(endpoint.url, url)
+        XCTAssertEqual(endpoint.urlRequest.url, url)
+    }
+    
+    func testURLRequest() throws {
+        let urlRequest = URLRequest(url: url)
+        let endpoint = Endpoint(urlRequest: urlRequest)
+        XCTAssertEqual(endpoint.urlRequest, urlRequest)
     }
     
     func testParse() throws {

--- a/Tests/TinyNetworkTests/URLSession+EndpointTests.swift
+++ b/Tests/TinyNetworkTests/URLSession+EndpointTests.swift
@@ -170,22 +170,22 @@ class URLSessionEndpointTests: XCTestCase {
             .store(in: &cancellables)
         wait(for: [expectation], timeout: 3)
     }
-}
+    
+    // MARK: - Mocks
 
-// MARK: - Mocks
+    struct MockResource: Codable, Equatable {
+        let name: String
 
-private struct MockResource: Codable, Equatable {
-    let name: String
-
-    static var sample: Self {
-        MockResource(name: "foobar")
+        static var sample: Self {
+            MockResource(name: "foobar")
+        }
     }
-}
 
-private struct OtherMockResource: Codable {
-    let fullname: String
+    struct OtherMockResource: Codable {
+        let fullname: String
 
-    static var sample: Self {
-        OtherMockResource(fullname: "barfoo")
+        static var sample: Self {
+            OtherMockResource(fullname: "barfoo")
+        }
     }
 }


### PR DESCRIPTION
Replace `URL` with `URLRequest` in the endpoint protocol to have more flexibility for the requests.